### PR TITLE
Cleans up dependency handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(pbwt C)
 
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 #add_custom_target(pbwt COMMAND make -C /Users/sayantand/Software/pbwt/ CLION_EXE_DIR=/Users/sayantand/Software/pbwt)
 
@@ -15,7 +15,30 @@ execute_process(COMMAND whoami OUTPUT_VARIABLE USER OUTPUT_STRIP_TRAILING_WHITES
 add_definitions(-DVERSION="${PROJECT_VERSION}" -DUSER="${USER}" -DDATE="${DATE}")
 
 find_package(ZLIB REQUIRED)
+find_package(BZip2 REQUIRED)
+find_package(LibLZMA REQUIRED)
 
+find_library(LIBM_LIBRARY m)
+if(NOT LIBM_LIBRARY)
+  message(FATAL_ERROR "libm not found")
+endif()
+
+find_library(HTS_LIBRARY hts)
+if(NOT HTS_LIBRARY)
+  message(FATAL_ERROR "htslib not found")
+endif()
+
+find_library(ZSTD_LIBRARY zstd)
+if(NOT ZSTD_LIBRARY)
+  message(FATAL_ERROR "libzstd not found")
+endif()
+
+find_library(STATGEN_LIBRARY StatGen)
+if(NOT STATGEN_LIBRARY)
+  message(FATAL_ERROR "libStatGen not found")
+endif()
+
+find_package(Threads)
 
 add_executable(pbwt
         src/array.c
@@ -41,7 +64,7 @@ add_executable(pbwt
         src/version.h)
 
 include_directories(/Users/sayantand/Software/htslib/)
-target_link_libraries(pbwt -lz -lm -lbz2 -llzma /Users/sayantand/Software/htslib/libhts.a ${STATGEN_LIBRARY} ${ZLIB_LIBRARIES})
+target_link_libraries(pbwt ${HTS_LIBRARY} ${STATGEN_LIBRARY} ${LIBM_LIBRARY} ${BZIP2_LIBRARIES} ${LIBLZMA_LIBRARIES} ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS pbwt RUNTIME DESTINATION bin)
 

--- a/dep/htslib.cmake
+++ b/dep/htslib.cmake
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.2)
+project(htslib VERSION 1.3.1)
+
+get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+foreach(dir ${dirs})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${dir}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${dir}")
+endforeach()
+message("dirs: ${dirs}")
+message("cxxflags: ${CMAKE_CXX_FLAGS}")
+
+#list(APPEND CMAKE_C_FLAGS ${dirs})
+#list(APPEND CMAKE_CXX_FLAGS ${dirs})
+
+#execute_process(COMMAND ./configure --disable-libcurl --disable-lzma --disable-bz2 --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(ENV{CFLAGS}  "${CMAKE_C_FLAGS}")
+set(ENV{CXXFLAGS} "${CMAKE_CXX_FLAGS}")
+set(ENV{LDFLAGS} "-L${CMAKE_PREFIX_PATH}/lib")
+
+#set(ENV{CFLAGS} "${CMAKE_C_FLAGS} $ENV{CFLAGS}")
+#set(ENV{CXXFLAGS} "${CMAKE_CXX_FLAGS} $ENV{CXXFLAGS}")
+#set(ENV{AM_CFLAGS} -I${CGET_PREFIX}/include)
+#set(ENV{CPPFLAGS} -I${CGET_PREFIX}/include)
+
+execute_process(COMMAND ./configure --disable-libcurl --disable-lzma --disable-bz2 --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}hts${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}hts${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                   COMMAND $(MAKE)
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Building htslib ...")
+add_custom_target(hts ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}hts${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}hts${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+#add_custom_target(hts ALL
+                  #COMMAND $(MAKE)
+                  #WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" 
+                  #COMMENT "Building htslib ...")
+
+install(DIRECTORY htslib DESTINATION include)
+
+if (BUILD_SHARED_LIBS)
+    install(FILES
+            ${CMAKE_SHARED_LIBRARY_PREFIX}hts${CMAKE_SHARED_LIBRARY_SUFFIX}
+            DESTINATION lib)
+    install(FILES
+            ${CMAKE_SHARED_LIBRARY_PREFIX}hts.1${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${CMAKE_SHARED_LIBRARY_PREFIX}hts${CMAKE_SHARED_LIBRARY_SUFFIX}.1
+            DESTINATION lib
+            OPTIONAL)
+else()
+    install(FILES
+            ${CMAKE_STATIC_LIBRARY_PREFIX}hts${CMAKE_STATIC_LIBRARY_SUFFIX}
+            DESTINATION lib)
+endif()

--- a/dep/libstatgen.cmake
+++ b/dep/libstatgen.cmake
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.2)
+project(libStatGen VERSION 1.0.0)
+
+get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+foreach(dir ${dirs})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${dir}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${dir}")
+endforeach()
+message("dirs: ${dirs}")
+message("cflags: ${CMAKE_C_FLAGS}")
+message("cxxflags: ${CMAKE_CXX_FLAGS}")
+
+set(ENV{CFLAGS} "-I/home/lefaivej/ipbwt/cget/include") # "${CMAKE_C_FLAGS}")
+set(ENV{CXXFLAGS} "-I/home/lefaivej/ipbwt/cget/include") #"${CMAKE_CXX_FLAGS}")
+set(ENV{LDFLAGS} "-L${CMAKE_PREFIX_PATH}/lib")
+
+#execute_process(COMMAND ./configure --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(libStatGen ALL 
+  COMMAND ${CMAKE_COMMAND} -E env CFLAGS="\"${CMAKE_C_FLAGS}\"" LDFLAGS="-L${CMAKE_PREFIX_PATH}/lib" make
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
+  COMMENT "Builing libStatGen ...")
+
+file(GLOB_RECURSE LSG_HEADER_LIST "bam/*.h" "fastq/*.h" "general/*.h" "glf/*.h" "samtools/*.h" "vcf/*.h")
+install(FILES ${LSG_HEADER_LIST} DESTINATION include)
+
+if (BUILD_SHARED_LIBS)
+    install(FILES ${CMAKE_SHARED_LIBRARY_PREFIX}StatGen${CMAKE_SHARED_LIBRARY_SUFFIX} DESTINATION lib)
+else()
+    install(FILES ${CMAKE_STATIC_LIBRARY_PREFIX}StatGen${CMAKE_STATIC_LIBRARY_SUFFIX} DESTINATION lib)
+endif()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+zlib,http://zlib.net/zlib-1.2.11.tar.gz
+htslib,https://github.com/samtools/htslib/releases/download/1.6/htslib-1.6.tar.bz2 --hash md5:d6fd14e208aca7e08cbe9072233d0af9 -DCMAKE_VERBOSE_MAKEFILE=1 --cmake dep/htslib.cmake
+statgen/libStatGen@cram-support --cmake dep/libstatgen.cmake


### PR DESCRIPTION
This has been tested on centos7. Note that you won't need to link against bz2, lzma and zstd if you install htslib via cget. 